### PR TITLE
Use a relative path to point to the root of the project.

### DIFF
--- a/src/ComposerPlugin.php
+++ b/src/ComposerPlugin.php
@@ -44,7 +44,7 @@ final class ComposerPlugin
     $this->debugMessage("Writing hh_autoload.php");
     (new Writer())
       ->setBuilder($importer)
-      ->setRoot($this->pathDifference($this->vendor, $this->root));
+      ->setRoot($this->root)
       ->writeToFile($this->vendor.'/hh_autoload.php');
   }
 
@@ -52,29 +52,5 @@ final class ComposerPlugin
     if ($this->io->isDebug()) {
       $this->io->write('hhvm-autoload: '.$message);
     }
-  }
-
-  private function pathDifference(\HH\string $from, \HH\string $to) {
-    $realFrom = realpath($from);
-    $realTo = realpath($to);
-
-    // Check if on different Windows drives
-    if(substr($realFrom, 0, 1) !== substr($realTo, 0, 1)) {
-      throw new \RuntimeException('Cannot find difference in path for separate drives.');
-    }
-
-    $fromParts = explode(DIRECTORY_SEPERATOR, realpath($from));
-    $toParts = explode(DIRECTORY_SEPERATOR, realpath($to));
-
-    // Remove common paths from the front
-    while(count($fromParts) && count($toParts) && $fromParts[0] === $toParts[0]) {
-      array_shift($fromParts);
-      array_shift($toParts);
-    }
-
-    // Trasform the left over from parts to ..
-    $upParts = array_map(function($part) { return '..'; }, $fromParts);
-
-    return implode(DIRECTORY_SEPERATOR, array_merge($upParts, $toParts));
   }
 }

--- a/src/ComposerPlugin.php
+++ b/src/ComposerPlugin.php
@@ -3,6 +3,7 @@
 namespace FredEmmott\AutoloadMap;
 
 use Composer\Composer;
+use Composer\Config;
 use Composer\EventDispatcher\EventSubscriberInterface;
 use Composer\IO\IOInterface;
 use Composer\Plugin\PluginInterface;
@@ -18,10 +19,8 @@ final class ComposerPlugin
 
   public function activate(Composer $composer, IOInterface $io) {
     $this->io = $io;
-    $vendor = $composer->getConfig()->get('vendor-dir', '/');
-
-    $this->vendor = $vendor;
-    $this->root = dirname($vendor);
+    $this->vendor = $composer->getConfig()->get('vendor-dir');
+    $this->root = getcwd();
   }
 
   public static function getSubscribedEvents() {
@@ -41,11 +40,11 @@ final class ComposerPlugin
 
     $this->debugMessage("Parsing tree");
     $importer = new RootImporter($this->root);
-   
-    $this->debugMessage("Writing hh_autoload.php"); 
+
+    $this->debugMessage("Writing hh_autoload.php");
     (new Writer())
       ->setBuilder($importer)
-      ->setRoot($this->root)
+      ->setRoot($this->pathDifference($this->vendor, $this->root));
       ->writeToFile($this->vendor.'/hh_autoload.php');
   }
 
@@ -53,5 +52,29 @@ final class ComposerPlugin
     if ($this->io->isDebug()) {
       $this->io->write('hhvm-autoload: '.$message);
     }
+  }
+
+  private function pathDifference(\HH\string $from, \HH\string $to) {
+    $realFrom = realpath($from);
+    $realTo = realpath($to);
+
+    // Check if on different Windows drives
+    if(substr($realFrom, 0, 1) !== substr($realTo, 0, 1)) {
+      throw new \RuntimeException('Cannot find difference in path for separate drives.');
+    }
+
+    $fromParts = explode(DIRECTORY_SEPERATOR, realpath($from));
+    $toParts = explode(DIRECTORY_SEPERATOR, realpath($to));
+
+    // Remove common paths from the front
+    while(count($fromParts) && count($toParts) && $fromParts[0] === $toParts[0]) {
+      array_shift($fromParts);
+      array_shift($toParts);
+    }
+
+    // Trasform the left over from parts to ..
+    $upParts = array_map(function($part) { return '..'; }, $fromParts);
+
+    return implode(DIRECTORY_SEPERATOR, array_merge($upParts, $toParts));
   }
 }

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -3,9 +3,11 @@
 namespace FredEmmott\AutoloadMap;
 
 final class Writer {
+  const string DS = '/';
   private ?ImmVector<string> $files;
   private ?AutoloadMap $map;
   private ?string $root;
+  private int $updirs = 0;
 
   public function setFiles(ImmVector<string> $files): this {
     $this->files = $files;
@@ -24,13 +26,11 @@ final class Writer {
   }
 
   public function setRoot(string $root): this {
-    $this->root = $root;
+    $this->root = realpath($root);
     return $this;
   }
 
-  public function writeToFile(
-    string $destination_file,
-  ): this {
+  public function writeToFile(string $destination_file): this {
     $files = $this->files;
     $map = $this->map;
 
@@ -38,61 +38,81 @@ final class Writer {
       throw new Exception('Call setFiles() before writeToFile()');
     }
     if ($map === null) {
-      throw new Exception('Call setAutoloadMap(0 before writeToFile()');
+      throw new Exception('Call setAutoloadMap() before writeToFile()');
     }
 
     $requires = implode(
       "\n",
       $files->map(
-        $file ==> 'require_once("'.$file.'");'
+        $file ==> 'require_once($root."'.$this->relativePath($file).'");',
       ),
     );
 
     $map = array_map(
-      function ($sub_map): array<string, string> {
+      function($sub_map): array<string, string> {
         assert(is_array($sub_map));
-        return array_map(
-          $path ==> $this->relativePath($path),
-          $sub_map,
-        );
+        return array_map($path ==> $this->relativePath($path), $sub_map);
       },
       Shapes::toArray($map),
     );
     $map = var_export($map, true);
-    $root = var_export($this->root.'/', true);
+
+    $root = $this->relativeRoot(dirname($destination_file));
     $code = <<<EOF
 <?hh
 
 /// Generated file, do not edit by hand ///
-
+\$root = $root;
 $requires
 
-HH\autoload_set_paths($map, $root);
+HH\autoload_set_paths($map, \$root);
 EOF;
-    file_put_contents(
-      $destination_file,
-      $code,
-    );
+    file_put_contents($destination_file, $code);
 
     return $this;
   }
 
   <<__Memoize>>
-  private function relativePath(
-    string $path,
-  ): string {
+  private function relativePath(string $path): string {
     $root = $this->root;
     if ($root === null) {
       throw new Exception('Call setRoot() before writeToFile()');
     }
     $path = realpath($path);
     if (strpos($path, $root) !== 0) {
-      throw new Exception(
-        "%s is outside root %s",
-        $path,
-        $root,
-      );
+      throw new Exception("%s is outside root %s", $path, $root);
     }
     return substr($path, strlen($root) + 1);
+  }
+
+  private function relativeRoot(string $destination_dir): string {
+    $from = realpath($destination_dir);
+    $to = (string) $this->root;
+
+    $from_parts = explode(self::DS, $from);
+    $to_parts = explode(self::DS, $to);
+
+    // Remove common paths from the front
+    while (count($from_parts) &&
+           count($to_parts) &&
+           $from_parts[0] === $to_parts[0]) {
+      array_shift($from_parts);
+      array_shift($to_parts);
+    }
+
+    $up_count = count($from_parts);
+
+    if ($up_count === 0) {
+      return var_export($to);
+    }
+
+    $open = str_repeat('dirname(', $up_count);
+    $close = str_repeat(')', $up_count);
+    $relative_to =
+      count($to_parts) > 0
+        ? self::DS.implode(self::DS, $to_parts).self::DS
+        : self::DS;
+
+    return $open.'__DIR__'.$close.'.'.var_export($relative_to, true);
   }
 }

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -24,7 +24,7 @@ final class Writer {
   }
 
   public function setRoot(string $root): this {
-    $this->root = realpath($root);
+    $this->root = $root;
     return $this;
   }
 
@@ -73,7 +73,7 @@ EOF;
       $destination_file,
       $code,
     );
-      
+
     return $this;
   }
 

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -29,7 +29,9 @@ final class Writer {
     return $this;
   }
 
-  public function writeToFile(string $destination_file): this {
+  public function writeToFile(
+    string $destination_file,
+  ): this {
     $files = $this->files;
     $map = $this->map;
 
@@ -48,14 +50,16 @@ final class Writer {
     );
 
     $map = array_map(
-      function($sub_map): array<string, string> {
+      function ($sub_map): array<string, string> {
         assert(is_array($sub_map));
-        return array_map($path ==> $this->relativePath($path), $sub_map);
+        return array_map(
+          $path ==> $this->relativePath($path),
+          $sub_map,
+        );
       },
       Shapes::toArray($map),
     );
     $map = var_export($map, true);
-
     $root = $this->relativeRoot(dirname($destination_file));
     $code = <<<EOF
 <?hh
@@ -66,20 +70,29 @@ $requires
 
 HH\autoload_set_paths($map, \$root);
 EOF;
-    file_put_contents($destination_file, $code);
+    file_put_contents(
+      $destination_file,
+      $code,
+    );
 
     return $this;
   }
 
   <<__Memoize>>
-  private function relativePath(string $path): string {
+  private function relativePath(
+    string $path,
+  ): string {
     $root = $this->root;
     if ($root === null) {
       throw new Exception('Call setRoot() before writeToFile()');
     }
     $path = realpath($path);
     if (strpos($path, $root) !== 0) {
-      throw new Exception("%s is outside root %s", $path, $root);
+      throw new Exception(
+        "%s is outside root %s",
+        $path,
+        $root,
+      );
     }
     return substr($path, strlen($root) + 1);
   }

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -7,7 +7,6 @@ final class Writer {
   private ?ImmVector<string> $files;
   private ?AutoloadMap $map;
   private ?string $root;
-  private int $updirs = 0;
 
   public function setFiles(ImmVector<string> $files): this {
     $this->files = $files;


### PR DESCRIPTION
Instead of using an absolute path to locate the root directory of the project from the autoload file, determine the relative path.

This will allow the autoload file to be built in an environment different than the runtime environment (i.e., build on host, run in a Docker container).  Additionally, this will address the custom vendor location issue in #7.

There is an assumption that the working directory is the same as the root path of the project at the time the plugin code is run.
